### PR TITLE
Set up RSO controller and views

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -20,3 +20,21 @@
   flex-direction: column;
   flex-grow: 0;
 }
+
+dl {
+  &.margins-removed {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.margins-removed dt {
+  margin: 0;
+  padding: 0;
+  font-weight: bold;
+}
+
+.margins-removed dd {
+  margin: 0 0 1em 0;
+  padding: 0;
+}

--- a/app/controllers/rso_controller.rb
+++ b/app/controllers/rso_controller.rb
@@ -1,0 +1,54 @@
+class RsoController < ApplicationController
+  before_action :authenticate_rso!, except: %i[launches new_rso signin_rso]
+  before_action :load_flight_card, only: %i[edit update]
+
+  def index
+    @flight_cards = @launch.flight_cards.waiting_for_rso
+    @approved = @launch.flight_cards.not_flown.where(rso_approved: true)
+                       .order(pad_assignment: :asc)
+  end
+
+  def edit; end
+
+  def update
+    if @flight_card.update(rso_params)
+      redirect_to rso_cards_path
+    else
+      render :edit, alert: 'Please try again.'
+    end
+  end
+
+  def launches
+    @launches = Launch.all
+  end
+
+  def new_rso
+    @launch = Launch.find(params[:id])
+  end
+
+  def signin_rso
+    @launch = Launch.find(params[:id])
+    if @launch&.authenticate_rso(params[:rso_key])
+      session[:launch_id] = @launch.id
+      redirect_to rso_cards_path
+    else
+      render :new_rso, alert: 'Something went wrong.'
+    end
+  end
+
+  private
+
+  def load_flight_card
+    @flight_card = FlightCard.find(params[:flight_card_id])
+  end
+
+  def rso_params
+    params.require(:flight_card).permit(:rso_approved, :pad_assignment)
+  end
+
+  def authenticate_rso!
+    @launch = Launch.find_by!(id: session[:launch_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to rso_launches_path
+  end
+end

--- a/app/models/flight_card.rb
+++ b/app/models/flight_card.rb
@@ -5,4 +5,6 @@ class FlightCard < ApplicationRecord
   belongs_to :launch
 
   scope :not_flown, -> { where.not(flown: true) }
+  scope :not_rso_approved, -> { where.not(rso_approved: true) }
+  scope :waiting_for_rso, -> { not_flown.not_rso_approved }
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex--row" style="margin-top: 12px;">
   <div class="flex--column">
     <%= link_to "I'm Flying", new_user_registration_path(role: 'flier'), class: 'waves-effect waves-light btn' %>
-    <button class="waves-effect waves-light btn">RSO</button>
+    <%= link_to 'RSO', rso_launches_path, class: 'waves-effect waves-light btn' %>
     <button class="waves-effect waves-light btn">LCO</button>
     <button class="waves-effect waves-light btn">Launch Admin</button>
   </div>

--- a/app/views/rso/edit.html.erb
+++ b/app/views/rso/edit.html.erb
@@ -1,0 +1,49 @@
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">Flier Info</span>
+    <h6>
+      <%= @flight_card.name %>
+    </h6>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">
+      <%= @flight_card.rocket_manufacturer %> <%= @flight_card.rocket_name %>
+    </span>
+    <dl class="margins-removed">
+      <dt>Rocket Type</dt>
+      <dd><%= @flight_card.rocket_type %></dd>
+      <dt>Stages</dt>
+      <dd><%= @flight_card.stages %></dd>
+      <dt>Cluster</dt>
+      <dd><%= @flight_card.cluster %></dd>
+      <dt>Launch Guide</dt>
+      <dd><%= @flight_card.launch_guide %></dd>
+      <dt>Recovery</dt>
+      <dd><%= (@flight_card.recovery&.keys || []).map { |r| r.titleize }.join(', ') %></dd>
+      <dt>Notes</dt>
+      <dd><%= @flight_card.chute_release %></dd>
+    </dl>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">RSO</span>
+    <%= form_with url: update_rso_card_path, model: @flight_card, method: :patch do |f| %>
+      <label>
+        <%= f.check_box :rso_approved, class: 'filled-in' %>
+        <span>RSO Approved</span>
+      </label>
+      <div class="input-field">
+        <%= f.telephone_field :pad_assignment %>
+        <%= f.label :pad_assignment %>
+      </div>
+
+      <%= f.submit 'Save', class: 'btn' %>
+      <%= link_to 'Cancel', rso_cards_path, class: 'btn-flat' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/rso/index.html.erb
+++ b/app/views/rso/index.html.erb
@@ -1,0 +1,13 @@
+<div class="collection with-header">
+  <div class="collection-header">Waiting Approval</div>
+  <% @flight_cards.each do |card| %>
+    <%= link_to "#{card.name} - #{card.rocket_name}", edit_rso_card_path(card), class: 'collection-item' %>
+  <% end %>
+  <div class="collection-header">Approved</div>
+  <% @approved.each do |card| %>
+    <%= link_to edit_rso_card_path(card), class: 'collection-item' do %>
+      <%= "#{card.name} - #{card.rocket_name}" %>
+      <span class="badge"><%= card.pad_assignment %></span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/rso/launches.html.erb
+++ b/app/views/rso/launches.html.erb
@@ -1,0 +1,5 @@
+<div class="collection">
+  <% @launches.each do |launch| %>
+    <%= link_to launch.name, sign_in_rso_path(launch), class: 'collection-item' %>
+  <% end %>
+</div>

--- a/app/views/rso/new_rso.html.erb
+++ b/app/views/rso/new_rso.html.erb
@@ -1,0 +1,13 @@
+<div class="card-container">
+  <div class="card-content">
+    <span class="card-title"><%= @launch.name %></span>
+    <%= form_with url: sign_in_rso_path(@launch), method: :post do |f| %>
+      <div class="input-field">
+        <%= f.text_field :rso_key %>
+        <%= f.label :rso_key, 'RSO Key' %>
+      </div>
+      <%= f.submit 'Sign In', class: 'btn' %>
+      <%= link_to 'Cancel', rso_launches_path, class: 'btn-flat' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,15 @@ Rails.application.routes.draw do
   root to: 'root#index'
   resources :flight_cards, only: %i[new create edit update index]
   resources :launches
+
+  scope :rso do
+    get 'launches', to: 'rso#launches', as: :rso_launches
+    get 'launches/:id', to: 'rso#new_rso', as: :sign_in_rso
+    post 'launches/:id', to: 'rso#signin_rso'
+
+    get '', to: 'rso#index', as: :rso_cards
+    get ':flight_card_id/edit', to: 'rso#edit', as: :edit_rso_card
+    put ':flight_card_id', to: 'rso#update'
+    patch ':flight_card_id', to: 'rso#update', as: :update_rso_card
+  end
 end


### PR DESCRIPTION
The RSO view will allow the user to approve flight cards and make pad assignments. It is password protected by a password the launch admin sets when setting up the launch.

When the RSO authenticates, we store the launch id in the session and use that for retrieving flight cards only for that launch.