### PR TITLE
Get mobile menu to open consistently

### DIFF
--- a/app/javascript/app/app.js
+++ b/app/javascript/app/app.js
@@ -1,0 +1,19 @@
+export class App {
+  static initApp() {
+    document.addEventListener('turbolinks:load', () => {
+      const elems = document.querySelectorAll('.sidenav');
+      const sidenav = window.M.Sidenav.init(elems, {})[0];
+
+      const trigger = document.getElementById('sidenav-trigger');
+      trigger.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (!sidenav) { return; }
+        if (sidenav.isOpen) {
+          sidenav.close();
+        } else {
+          sidenav.open();
+        }
+      });
+    });
+  }
+}

--- a/app/javascript/app/index.js
+++ b/app/javascript/app/index.js
@@ -1,0 +1,3 @@
+import { App } from './app';
+
+App.initApp();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,8 +6,8 @@
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
-require("channels")
-
+require("../channels")
+require('../app');
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
@@ -16,7 +17,7 @@
     <nav>
       <div class="nav-wrapper">
         <a href="/" class="brand-logo">Flight Cards</a>
-        <a href="#" data-target="slide-out" class="sidenav-trigger"><i class="material-icons">menu</i></a>
+        <a href="#" data-target="slide-out" class="sidenav-trigger" id="sidenav-trigger"><i class="material-icons">menu</i></a>
         <ul class="right hide-on-med-and-down">
           <% if current_user %>
             <li>
@@ -57,13 +58,5 @@
     <div class="main-container">
       <%= yield %>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script type="text/javascript" charset="utf-8">
-      document.addEventListener('DOMContentLoaded', function() {
-        var elems = document.querySelectorAll('.sidenav');
-        var options = {};
-        var instances = M.Sidenav.init(elems, options);
-      });
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Sidenav menu on mobile wasn't opening after navigation due to how Turbolinks works. Add some JS to init the sidenav after each turbolinks load event.