### PR TITLE
Nest routes under launches and add LCO/RSO switching capability

### DIFF
--- a/app/controllers/flight_cards_controller.rb
+++ b/app/controllers/flight_cards_controller.rb
@@ -1,16 +1,18 @@
 class FlightCardsController < ApplicationController
   before_action :authenticate_user!
   before_action :load_flight_card, only: %i[edit update duplicate show]
+  before_action :set_launch_session
 
   def new
-    session[:launch_id] = params[:launch] if params[:launch]
     @flight_card = current_user.flight_cards.new
   end
 
   def create
-    @flight_card = current_user.flight_cards.new(flight_card_params.merge(launch_id: session[:launch_id]))
+    @flight_card = current_user.flight_cards.new(
+      flight_card_params.merge(launch_id: params[:launch_id])
+    )
     if @flight_card.save
-      redirect_to flight_cards_path
+      redirect_to launch_flight_cards_path(params[:launch_id])
     else
       render :new, alert: 'Something went wrong.'
     end
@@ -25,28 +27,32 @@ class FlightCardsController < ApplicationController
       )
     )
     if @new_flight_card.save!
-      redirect_to edit_flight_card_path(@new_flight_card)
+      redirect_to edit_launch_flight_card_path(@new_flight_card)
     else
-      redirect_to flight_cards_path
+      redirect_to launch_flight_cards_path
     end
   end
 
   def index
-    @flight_cards = current_user.flight_cards.for_launch(session[:launch_id]).not_flown
-    @flown = current_user.flight_cards.for_launch(session[:launch_id]).flown
+    @flight_cards = current_user.flight_cards.for_launch(params[:launch_id]).not_flown
+    @flown = current_user.flight_cards.for_launch(params[:launch_id]).flown
   end
 
   def edit; end
 
   def update
     if @flight_card.update(flight_card_params)
-      redirect_to flight_cards_path
+      redirect_to launch_flight_cards_path
     else
       render :edit, alert: 'Something went wrong.'
     end
   end
 
   private
+
+  def set_launch_session
+    session[:launch_id] = params[:launch_id]
+  end
 
   def load_flight_card
     @flight_card = current_user.flight_cards.find(params[:id])

--- a/app/controllers/flight_cards_controller.rb
+++ b/app/controllers/flight_cards_controller.rb
@@ -27,9 +27,9 @@ class FlightCardsController < ApplicationController
       )
     )
     if @new_flight_card.save!
-      redirect_to edit_launch_flight_card_path(@new_flight_card)
+      redirect_to edit_launch_flight_card_path(params[:launch_id], @new_flight_card)
     else
-      redirect_to launch_flight_cards_path
+      redirect_to launch_flight_cards_path(params[:launch_id])
     end
   end
 
@@ -38,11 +38,9 @@ class FlightCardsController < ApplicationController
     @flown = current_user.flight_cards.for_launch(params[:launch_id]).flown
   end
 
-  def edit; end
-
   def update
     if @flight_card.update(flight_card_params)
-      redirect_to launch_flight_cards_path
+      redirect_to launch_flight_cards_path(params[:launch_id])
     else
       render :edit, alert: 'Something went wrong.'
     end

--- a/app/controllers/lco_controller.rb
+++ b/app/controllers/lco_controller.rb
@@ -8,7 +8,7 @@ class LcoController < ApplicationController
   end
 
   def update
-    @flight_card.update!(flown: params[:flown])
+    @flight_card.update!(flown: params[:flight_card][:flown])
     redirect_to launch_lco_cards_path(@launch)
   end
 
@@ -29,6 +29,7 @@ class LcoController < ApplicationController
     @launch = Launch.find(params[:launch_id])
     if @launch&.authenticate_lco(params[:lco_key])
       session[:launch_id] = @launch.id
+      session[:lco_login] = true
       redirect_to launch_lco_cards_path(@launch)
     else
       render :new_lco, alert: 'Something went wrong.'

--- a/app/controllers/lco_controller.rb
+++ b/app/controllers/lco_controller.rb
@@ -7,16 +7,14 @@ class LcoController < ApplicationController
     @flown = @launch.flight_cards.where(flown: true)
   end
 
-  def edit; end
-
   def update
     @flight_card.update!(flown: true)
-    redirect_to lco_cards_path
+    redirect_to launch_lco_cards_path(@launch)
   end
 
   def reset
     @flight_card.update!(rso_approved: false, pad_assignment: nil)
-    redirect_to lco_cards_path
+    redirect_to launch_lco_cards_path(@launch)
   end
 
   def launches
@@ -24,14 +22,14 @@ class LcoController < ApplicationController
   end
 
   def new_lco
-    @launch = Launch.find(params[:id])
+    @launch = Launch.find(params[:launch_id])
   end
 
   def signin_lco
-    @launch = Launch.find(params[:id])
+    @launch = Launch.find(params[:launch_id])
     if @launch&.authenticate_lco(params[:lco_key])
       session[:launch_id] = @launch.id
-      redirect_to lco_cards_path
+      redirect_to launch_lco_cards_path(@launch)
     else
       render :new_lco, alert: 'Something went wrong.'
     end
@@ -44,7 +42,7 @@ class LcoController < ApplicationController
   end
 
   def load_flight_card
-    @flight_card = FlightCard.find(params[:flight_card_id])
+    @flight_card = @launch.flight_cards.find(params[:flight_card_id])
   end
 
   def authenticate_lco!

--- a/app/controllers/lco_controller.rb
+++ b/app/controllers/lco_controller.rb
@@ -8,12 +8,12 @@ class LcoController < ApplicationController
   end
 
   def update
-    @flight_card.update!(flown: true)
+    @flight_card.update!(flown: params[:flown])
     redirect_to launch_lco_cards_path(@launch)
   end
 
   def reset
-    @flight_card.update!(rso_approved: false, pad_assignment: nil)
+    @flight_card.update!(rso_approved: false, pad_assignment: nil, flown: false)
     redirect_to launch_lco_cards_path(@launch)
   end
 

--- a/app/controllers/lco_controller.rb
+++ b/app/controllers/lco_controller.rb
@@ -50,6 +50,6 @@ class LcoController < ApplicationController
   def authenticate_lco!
     @launch = Launch.find_by!(id: session[:launch_id])
   rescue ActiveRecord::RecordNotFound
-    redirect_to rso_launches_path
+    redirect_to lco_launches_path
   end
 end

--- a/app/controllers/rso_controller.rb
+++ b/app/controllers/rso_controller.rb
@@ -3,16 +3,16 @@ class RsoController < ApplicationController
   before_action :load_flight_card, only: %i[edit update]
 
   def index
-    @flight_cards = @launch.flight_cards.waiting_for_rso
-    @approved = @launch.flight_cards.not_flown.where(rso_approved: true)
+    @flight_cards = @launch.flight_cards.for_launch(params[:launch_id])
+                           .waiting_for_rso
+    @approved = @launch.flight_cards.for_launch(params[:launch_id]).not_flown
+                       .where(rso_approved: true)
                        .order(pad_assignment: :asc)
   end
 
-  def edit; end
-
   def update
     if @flight_card.update(rso_params)
-      redirect_to rso_cards_path
+      redirect_to launch_rso_cards_path(params[:launch_id])
     else
       render :edit, alert: 'Please try again.'
     end
@@ -23,14 +23,14 @@ class RsoController < ApplicationController
   end
 
   def new_rso
-    @launch = Launch.find(params[:id])
+    @launch = Launch.find(params[:launch_id])
   end
 
   def signin_rso
-    @launch = Launch.find(params[:id])
+    @launch = Launch.find(params[:launch_id])
     if @launch&.authenticate_rso(params[:rso_key])
       session[:launch_id] = @launch.id
-      redirect_to rso_cards_path
+      redirect_to launch_rso_cards_path(@launch)
     else
       render :new_rso, alert: 'Something went wrong.'
     end
@@ -39,7 +39,7 @@ class RsoController < ApplicationController
   private
 
   def load_flight_card
-    @flight_card = FlightCard.find(params[:flight_card_id])
+    @flight_card = @launch.flight_cards.find(params[:flight_card_id])
   end
 
   def rso_params
@@ -47,7 +47,7 @@ class RsoController < ApplicationController
   end
 
   def authenticate_rso!
-    @launch = Launch.find_by!(id: session[:launch_id])
+    @launch ||= Launch.find_by!(id: session[:launch_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to rso_launches_path
   end

--- a/app/controllers/rso_controller.rb
+++ b/app/controllers/rso_controller.rb
@@ -30,6 +30,7 @@ class RsoController < ApplicationController
     @launch = Launch.find(params[:launch_id])
     if @launch&.authenticate_rso(params[:rso_key])
       session[:launch_id] = @launch.id
+      session[:rso_login] = true
       redirect_to launch_rso_cards_path(@launch)
     else
       render :new_rso, alert: 'Something went wrong.'

--- a/app/controllers/rso_controller.rb
+++ b/app/controllers/rso_controller.rb
@@ -49,6 +49,6 @@ class RsoController < ApplicationController
   def authenticate_rso!
     @launch ||= Launch.find_by!(id: session[:launch_id])
   rescue ActiveRecord::RecordNotFound
-    redirect_to rso_launches_path
+    redirect_to launch_sign_in_rso_path
   end
 end

--- a/app/models/flight_card.rb
+++ b/app/models/flight_card.rb
@@ -4,7 +4,7 @@ class FlightCard < ApplicationRecord
   belongs_to :user
   belongs_to :launch
 
-  scope :not_flown, -> { where.not(flown: true) }
+  scope :not_flown, -> { where("flown = 'f' OR flown IS NULL") }
   scope :flown, -> { where(flown: true) }
   scope :not_rso_approved, -> { where.not(rso_approved: true) }
   scope :waiting_for_rso, -> { not_flown.not_rso_approved }

--- a/app/views/flight_cards/edit.html.erb
+++ b/app/views/flight_cards/edit.html.erb
@@ -1,7 +1,7 @@
 <h2>Edit Flight Card</h2>
 
-<%= form_with model: @flight_card do |form| %>
+<%= form_with model: @flight_card, url: launch_flight_card_path(params[:launch_id]) do |form| %>
   <%= render partial: 'form', locals: {f: form} %>
   <%= form.submit 'Update', class: 'btn' %>
-  <%= link_to 'Back', flight_cards_path, class: 'btn-flat' %>
+  <%= link_to 'Back', launch_flight_cards_path, class: 'btn-flat' %>
 <% end %>

--- a/app/views/flight_cards/index.html.erb
+++ b/app/views/flight_cards/index.html.erb
@@ -1,11 +1,11 @@
-<%= link_to 'Create Flight Card', new_flight_card_path, class: 'btn' %>
+<%= link_to 'Create Flight Card', new_launch_flight_card_path(params[:launch_id]), class: 'btn' %>
 <div class="collection with-header">
   <div class="collection-header">Waiting to fly</div>
   <% @flight_cards.each do |fc| %>
-    <%= link_to fc.rocket_name, edit_flight_card_path(fc), class: 'collection-item' %>
+    <%= link_to fc.rocket_name, edit_launch_flight_card_path(params[:launch_id], fc), class: 'collection-item' %>
   <% end %>
   <div class="collection-header">Flown</div>
   <% @flown.each do |fc| %>
-    <%= link_to fc.rocket_name, flight_card_path(fc), class: 'collection-item' %>
+    <%= link_to fc.rocket_name, launch_flight_card_path(params[:launch_id], fc), class: 'collection-item' %>
   <% end %>
 </div>

--- a/app/views/flight_cards/new.html.erb
+++ b/app/views/flight_cards/new.html.erb
@@ -1,7 +1,7 @@
 <h2>New Flight Card</h2>
 
-<%= form_with model: @flight_card do |form| %>
+<%= form_with model: @flight_card, url: new_launch_flight_card_path(params[:launch_id]) do |form| %>
   <%= render partial: 'form', locals: {f: form} %>
   <%= form.submit 'Create', class: 'btn' %>
-  <%= link_to 'Cancel', flight_cards_path, class: 'btn-flat' %>
+  <%= link_to 'Cancel', launch_flight_cards_path(params[:launch_id]), class: 'btn-flat' %>
 <% end %>

--- a/app/views/flight_cards/show.html.erb
+++ b/app/views/flight_cards/show.html.erb
@@ -32,4 +32,4 @@
   </div>
 </div>
 
-<%= link_to 'Duplicate', duplicate_flight_card_path(@flight_card), method: :post, class: 'btn' %>
+<%= link_to 'Duplicate', duplicate_launch_flight_card_path(params[:launch_id], @flight_card), method: :post, class: 'btn' %>

--- a/app/views/launches/index.html.erb
+++ b/app/views/launches/index.html.erb
@@ -6,7 +6,7 @@
     <% if policy(launch).update? %>
       <%= link_to launch.name, edit_launch_path(launch), class: 'collection-item' %>
     <% else %>
-      <%= link_to launch.name, new_flight_card_path(launch: launch.id), class: 'collection-item' %>
+      <%= link_to launch.name, new_launch_flight_card_path(launch), class: 'collection-item' %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,12 @@
               <%= link_to 'Launches', launches_path %>
             </li>
             <li>
+              <%= link_to 'RSO', rso_launches_path %>
+            </li>
+            <li>
+              <%= link_to 'LCO', lco_launches_path %>
+            </li>
+            <li>
               <%= link_to 'Sign Out', destroy_user_session_path, method: 'delete' %>
             </li>
           <% else %>
@@ -49,6 +55,12 @@
         <% end %>
         <li>
           <%= link_to 'Launches', launches_path %>
+        </li>
+        <li>
+          <%= link_to 'RSO', rso_launches_path %>
+        </li>
+        <li>
+          <%= link_to 'LCO', lco_launches_path %>
         </li>
         <li>
           <%= link_to 'Sign Out', destroy_user_session_path, method: 'delete' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,15 +29,19 @@
               <%= link_to 'Launches', launches_path %>
             </li>
             <li>
-              <%= link_to 'RSO', rso_launches_path %>
+              <%= link_to 'RSO', session[:rso_login] ? launch_rso_cards_path(session[:launch_id]) : rso_launches_path %>
             </li>
             <li>
-              <%= link_to 'LCO', lco_launches_path %>
+              <%= link_to 'LCO', session[:lco_login] ? launch_lco_cards_path(session[:launch_id]) : lco_launches_path %>
             </li>
             <li>
               <%= link_to 'Sign Out', destroy_user_session_path, method: 'delete' %>
             </li>
           <% else %>
+            <% if session[:launch_id].present? %>
+              <li><%= link_to 'RSO', launch_rso_cards_path(session[:launch_id]) %></li>
+              <li><%= link_to 'LCO', launch_lco_cards_path(session[:launch_id]) %></li>
+            <% end %>
             <li>
               <%= link_to 'Sign In', new_user_session_path %>
             </li>
@@ -57,15 +61,19 @@
           <%= link_to 'Launches', launches_path %>
         </li>
         <li>
-          <%= link_to 'RSO', rso_launches_path %>
+          <%= link_to 'RSO', session[:rso_login] ? launch_rso_cards_path(session[:launch_id]) : rso_launches_path %>
         </li>
         <li>
-          <%= link_to 'LCO', lco_launches_path %>
+          <%= link_to 'LCO', session[:lco_login] ? launch_lco_cards_path(session[:launch_id]) : lco_launches_path %>
         </li>
         <li>
           <%= link_to 'Sign Out', destroy_user_session_path, method: 'delete' %>
         </li>
       <% else %>
+        <% if session[:launch_id].present? %>
+          <li><%= link_to 'RSO', launch_rso_cards_path(session[:launch_id]) %></li>
+          <li><%= link_to 'LCO', launch_lco_cards_path(session[:launch_id]) %></li>
+        <% end %>
         <li>
           <%= link_to 'Sign In', new_user_session_path %>
         </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,9 +20,11 @@
         <a href="#" data-target="slide-out" class="sidenav-trigger" id="sidenav-trigger"><i class="material-icons">menu</i></a>
         <ul class="right hide-on-med-and-down">
           <% if current_user %>
-            <li>
-              <%= link_to 'Flight Cards', flight_cards_path %>
-            </li>
+            <% if session[:launch_id] %>
+              <li>
+                <%= link_to 'Flight Cards', launch_flight_cards_path(session[:launch_id]) %>
+              </li>
+            <% end %>
             <li>
               <%= link_to 'Launches', launches_path %>
             </li>
@@ -40,9 +42,11 @@
 
     <ul class="sidenav" id="slide-out">
       <% if current_user %>
-        <li>
-          <%= link_to 'Flight Cards', flight_cards_path %>
-        </li>
+        <% if session[:launch_id] %>
+          <li>
+            <%= link_to 'Flight Cards', launch_flight_cards_path(session[:launch_id]) %>
+          </li>
+        <% end %>
         <li>
           <%= link_to 'Launches', launches_path %>
         </li>

--- a/app/views/lco/edit.html.erb
+++ b/app/views/lco/edit.html.erb
@@ -37,10 +37,14 @@
     <span class="card-title">LCO</span>
     <!-- Good Flight -->
     <%= form_with model: @flight_card, url: launch_update_lco_card_path, method: :patch do |f| %>
+      <%= f.hidden_field :flown, value: true %>
       <button type="submit" class="waves-effect waves-light btn">Flown</button>
     <% end %>
 
-    <%= link_to 'Not Flown', launch_lco_cards_path, class: 'btn' %>
+    <%= form_with model: @flight_card, url: launch_update_lco_card_path, method: :patch do |f| %>
+      <%= f.hidden_field :flown, value: false %>
+      <button type="submit" class="waves-effect waves-light btn">Not Flown</button>
+    <% end %>
 
     <!-- Reset -->
     <%= form_with model: @flight_card, url: launch_update_lco_card_path, method: :delete do |f| %>

--- a/app/views/lco/edit.html.erb
+++ b/app/views/lco/edit.html.erb
@@ -37,12 +37,14 @@
     <span class="card-title">LCO</span>
     <!-- Good Flight -->
     <%= form_with model: @flight_card, url: update_lco_card_path, method: :patch do |f| %>
-      <button type="submit" class="waves-effect waves-light btn">Good Flight</button>
+      <button type="submit" class="waves-effect waves-light btn">Flown</button>
     <% end %>
+
+    <%= link_to 'Not Flown', lco_cards_path, class: 'btn' %>
 
     <!-- Reset -->
     <%= form_with model: @flight_card, url: update_lco_card_path, method: :delete do |f| %>
-      <button type="submit" class="waves-effect waves-light btn red">Reset</button>
+      <button type="submit" class="waves-effect waves-light btn red">Back to RSO</button>
     <% end %>
   </div>
 </div>

--- a/app/views/lco/edit.html.erb
+++ b/app/views/lco/edit.html.erb
@@ -36,14 +36,14 @@
   <div class="card-content">
     <span class="card-title">LCO</span>
     <!-- Good Flight -->
-    <%= form_with model: @flight_card, url: update_lco_card_path, method: :patch do |f| %>
+    <%= form_with model: @flight_card, url: launch_update_lco_card_path, method: :patch do |f| %>
       <button type="submit" class="waves-effect waves-light btn">Flown</button>
     <% end %>
 
-    <%= link_to 'Not Flown', lco_cards_path, class: 'btn' %>
+    <%= link_to 'Not Flown', launch_lco_cards_path, class: 'btn' %>
 
     <!-- Reset -->
-    <%= form_with model: @flight_card, url: update_lco_card_path, method: :delete do |f| %>
+    <%= form_with model: @flight_card, url: launch_update_lco_card_path, method: :delete do |f| %>
       <button type="submit" class="waves-effect waves-light btn red">Back to RSO</button>
     <% end %>
   </div>

--- a/app/views/lco/index.html.erb
+++ b/app/views/lco/index.html.erb
@@ -1,14 +1,14 @@
 <div class="collection with-header">
   <div class="collection-header">Waiting for Flight</div>
   <% @flight_cards.each do |card| %>
-    <%= link_to edit_lco_card_path(card), class: 'collection-item' do %>
+    <%= link_to launch_edit_lco_card_path(params[:launch_id], card), class: 'collection-item' do %>
       <%= "#{card.name} - #{card.rocket_name}" %>
       <span class="badge"><%= card.pad_assignment %></span>
     <% end %>
   <% end %>
   <div class="collection-header">Flown</div>
   <% @flown.each do |card| %>
-    <%= link_to edit_lco_card_path(card), class: 'collection-item' do %>
+    <%= link_to launch_edit_lco_card_path(params[:launch_id], card), class: 'collection-item' do %>
       <%= "#{card.name} - #{card.rocket_name}" %>
       <span class="badge"><%= card.pad_assignment %></span>
     <% end %>

--- a/app/views/lco/launches.html.erb
+++ b/app/views/lco/launches.html.erb
@@ -1,5 +1,5 @@
 <div class="collection">
   <% @launches.each do |launch| %>
-    <%= link_to launch.name, sign_in_lco_path(launch), class: 'collection-item' %>
+    <%= link_to launch.name, launch_sign_in_lco_path(launch), class: 'collection-item' %>
   <% end %>
 </div>

--- a/app/views/lco/new_lco.html.erb
+++ b/app/views/lco/new_lco.html.erb
@@ -1,7 +1,7 @@
 <div class="card-container">
   <div class="card-content">
     <span class="card-title"><%= @launch.name %></span>
-    <%= form_with url: sign_in_lco_path(@launch), method: :post do |f| %>
+    <%= form_with url: launch_sign_in_lco_path(@launch), method: :post do |f| %>
       <div class="input-field">
         <%= f.text_field :lco_key %>
         <%= f.label :lco_key, 'LCO Key' %>

--- a/app/views/rso/edit.html.erb
+++ b/app/views/rso/edit.html.erb
@@ -13,6 +13,8 @@
       <%= @flight_card.rocket_manufacturer %> <%= @flight_card.rocket_name %>
     </span>
     <dl class="margins-removed">
+      <dt>Motor</dt>
+      <dd><%= @flight_card.motor_manufacturer %> <%= @flight_card.motor %></dd>
       <dt>Rocket Type</dt>
       <dd><%= @flight_card.rocket_type %></dd>
       <dt>Stages</dt>

--- a/app/views/rso/edit.html.erb
+++ b/app/views/rso/edit.html.erb
@@ -34,7 +34,7 @@
 <div class="card">
   <div class="card-content">
     <span class="card-title">RSO</span>
-    <%= form_with url: update_rso_card_path, model: @flight_card, method: :patch do |f| %>
+    <%= form_with url: launch_update_rso_card_path, model: @flight_card, method: :patch do |f| %>
       <label>
         <%= f.check_box :rso_approved, class: 'filled-in' %>
         <span>RSO Approved</span>
@@ -45,7 +45,7 @@
       </div>
 
       <%= f.submit 'Save', class: 'btn' %>
-      <%= link_to 'Cancel', rso_cards_path, class: 'btn-flat' %>
+      <%= link_to 'Cancel', launch_rso_cards_path, class: 'btn-flat' %>
     <% end %>
   </div>
 </div>

--- a/app/views/rso/index.html.erb
+++ b/app/views/rso/index.html.erb
@@ -1,11 +1,11 @@
 <div class="collection with-header">
   <div class="collection-header">Waiting Approval</div>
   <% @flight_cards.each do |card| %>
-    <%= link_to "#{card.name} - #{card.rocket_name}", edit_rso_card_path(card), class: 'collection-item' %>
+    <%= link_to "#{card.name} - #{card.rocket_name}", launch_edit_rso_card_path(params[:launch_id], card), class: 'collection-item' %>
   <% end %>
   <div class="collection-header">Approved</div>
   <% @approved.each do |card| %>
-    <%= link_to edit_rso_card_path(card), class: 'collection-item' do %>
+    <%= link_to launch_edit_rso_card_path(params[:launch_id], card), class: 'collection-item' do %>
       <%= "#{card.name} - #{card.rocket_name}" %>
       <span class="badge"><%= card.pad_assignment %></span>
     <% end %>

--- a/app/views/rso/launches.html.erb
+++ b/app/views/rso/launches.html.erb
@@ -1,5 +1,5 @@
 <div class="collection">
   <% @launches.each do |launch| %>
-    <%= link_to launch.name, sign_in_rso_path(launch), class: 'collection-item' %>
+    <%= link_to launch.name, launch_sign_in_rso_path(launch), class: 'collection-item' %>
   <% end %>
 </div>

--- a/app/views/rso/new_rso.html.erb
+++ b/app/views/rso/new_rso.html.erb
@@ -1,7 +1,7 @@
 <div class="card-container">
   <div class="card-content">
     <span class="card-title"><%= @launch.name %></span>
-    <%= form_with url: sign_in_rso_path(@launch), method: :post do |f| %>
+    <%= form_with url: launch_sign_in_rso_path(@launch), method: :post do |f| %>
       <div class="input-field">
         <%= f.text_field :rso_key %>
         <%= f.label :rso_key, 'RSO Key' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'root#index'
-  resources :flight_cards do
-    post 'duplicate', on: :member, to: 'flight_cards#duplicate', as: :duplicate
+
+  resources :launches do
+    resources :flight_cards do
+      post 'duplicate', on: :member, to: 'flight_cards#duplicate', as: :duplicate
+    end
   end
-  resources :launches
 
   scope :rso do
     get 'launches', to: 'rso#launches', as: :rso_launches

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,17 +6,17 @@ Rails.application.routes.draw do
     resources :flight_cards do
       post 'duplicate', on: :member, to: 'flight_cards#duplicate', as: :duplicate
     end
-  end
 
-  scope :rso do
-    get 'launches', to: 'rso#launches', as: :rso_launches
-    get 'launches/:id', to: 'rso#new_rso', as: :sign_in_rso
-    post 'launches/:id', to: 'rso#signin_rso'
+    scope :rso do
+      get '', on: :collection, to: 'rso#launches', as: :rso
+      get 'new', to: 'rso#new_rso'
+      post '', to: 'rso#signin_rso', as: :sign_in_rso
 
-    get '', to: 'rso#index', as: :rso_cards
-    get ':flight_card_id/edit', to: 'rso#edit', as: :edit_rso_card
-    put ':flight_card_id', to: 'rso#update'
-    patch ':flight_card_id', to: 'rso#update', as: :update_rso_card
+      get '', to: 'rso#index', as: :rso_cards
+      get 'flight_cards/:flight_card_id/edit', to: 'rso#edit', as: :edit_rso_card
+      put 'flight_cards/:flight_card_id', to: 'rso#update'
+      patch 'flight_cards/:flight_card_id', to: 'rso#update', as: :update_rso_card
+    end
   end
 
   scope :lco do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,17 +17,17 @@ Rails.application.routes.draw do
       put 'flight_cards/:flight_card_id', to: 'rso#update'
       patch 'flight_cards/:flight_card_id', to: 'rso#update', as: :update_rso_card
     end
-  end
 
-  scope :lco do
-    get 'launches', to: 'lco#launches', as: :lco_launches
-    get 'launches/:id', to: 'lco#new_lco', as: :sign_in_lco
-    post 'launches/:id', to: 'lco#signin_lco'
+    scope :lco do
+      get '', on: :collection, to: 'lco#launches', as: :lco
+      get 'new', to: 'lco#new_lco', as: :sign_in_lco
+      post 'new', to: 'lco#signin_lco'
 
-    get '', to: 'lco#index', as: :lco_cards
-    get ':flight_card_id/edit', to: 'lco#edit', as: :edit_lco_card
-    put ':flight_card_id', to: 'lco#update'
-    patch ':flight_card_id', to: 'lco#update', as: :update_lco_card
-    delete ':flight_card_id', to: 'lco#reset', as: :reset_lco_card
+      get '', to: 'lco#index', as: :lco_cards
+      get 'flight_cards/:flight_card_id/edit', to: 'lco#edit', as: :edit_lco_card
+      put 'flight_cards/:flight_card_id', to: 'lco#update'
+      patch 'flight_cards/:flight_card_id', to: 'lco#update', as: :update_lco_card
+      delete 'flight_cards/:flight_card_id', to: 'lco#reset', as: :reset_lco_card
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
 
     scope :rso do
       get '', on: :collection, to: 'rso#launches', as: :rso
-      get 'new', to: 'rso#new_rso'
-      post '', to: 'rso#signin_rso', as: :sign_in_rso
+      get 'new', to: 'rso#new_rso', as: :sign_in_rso
+      post 'new', to: 'rso#signin_rso'
 
       get '', to: 'rso#index', as: :rso_cards
       get 'flight_cards/:flight_card_id/edit', to: 'rso#edit', as: :edit_rso_card


### PR DESCRIPTION
Nest the routes under `/launches` so we can be explicit with what launch we're dealing with instead of relying on a session value. Makes switching easier to keep track of.

Also allow switching to RSO/LCO from the menu. This way a person can fly and jump in to RSO or LCO roles at the same time.