### PR TITLE
Import Materialize scss files and change colors

### DIFF
--- a/app/javascript/app/styles/app.scss
+++ b/app/javascript/app/styles/app.scss
@@ -1,0 +1,4 @@
+@import '~materialize-css/sass/components/color-variables';
+$primary-color: color('blue', 'darken-1') !default;
+$secondary-color: color('deep-orange', 'base') !default;
+@import '~materialize-css/sass/materialize';

--- a/app/javascript/packs/stylesheets.scss
+++ b/app/javascript/packs/stylesheets.scss
@@ -1,0 +1,1 @@
+@import '../app/styles/app';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,8 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'stylesheets' %>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
@@ -16,9 +16,9 @@
   <body class="blue-grey lighten-5">
     <div class="flash-container">
       <% flash.each do |type, message| %>
-        <div class="flash <%= type.to_s == 'alert' ? 'red accent-2' : 'green lighten-1' %>">
+        <div class="flash <%= type.to_s == 'alert' ? 'red' : 'green lighten-1' %>">
           <%= message %>
-          <button class="flash-close <%= type == 'alert' ? 'red accent-2' : 'green lighten-1' %>"><i class="material-icons">close</i></button>
+          <button class="flash-close <%= type == 'alert' ? 'red' : 'green lighten-1' %>"><i class="material-icons">close</i></button>
         </div>
       <% end %>
     </div>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "materialize-css": "^1.0.0-rc.2",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4169,6 +4169,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+materialize-css@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/materialize-css/-/materialize-css-1.0.0-rc.2.tgz#b9e6b18f698c6ef77bb6b628d59147faf131eff5"
+  integrity sha512-FuQmSyq4Qv0ov7A2qXw0E6/jbQzSWx2P1pg2/XQDYTkkSc/GyiFAxu3fw9zgShwuTvyumEiw5jkxQWT9siqMBQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
Not wild about the default Materialize theme. So set up the project to compile the source Materialize SCSS files so we can override the primary and secondary colors.